### PR TITLE
socket name for keepassxc 2.6

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::str;
 
-static KEEPASS_SOCKET_NAME: &str = "kpxc_server";
+static KEEPASS_SOCKET_NAME: &str = "org.keepassxc.KeePassXC.BrowserServer";
 
 #[macro_export]
 macro_rules! error {


### PR DESCRIPTION
The name of the socket has changed from kpxc_server to org.keepassxc.KeePassXC.BrowserServer.

See https://github.com/keepassxreboot/keepassxc/pull/4680/files#diff-071572095d5d87a566ebab7767193a6fR38