### PR TITLE
exit code != 0 on error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -747,5 +747,6 @@ fn main() {
             .map(|s| s.to_string())
             .unwrap_or_else(|| "N/A".to_string());
         error!("{}, Caused by: {}", e, source);
+        std::process::exit(1);
     }
 }


### PR DESCRIPTION
It's really hard to use this in scripts otherwise.