### PR TITLE
Support running tests without yubikey feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,11 @@ jobs:
           command: clippy
           args: --features=all -- -D warnings
 
+      - name: "Test (No Features)"
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release
       - name: "Test (No strict-caller)"
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -138,6 +138,11 @@ jobs:
             target/release/git-credential-keepassxc
             target/release/git-credential-keepassxc.exe
 
+      - name: "Test (No Features)"
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release
       - name: "Test (No strict-caller)"
         uses: actions-rs/cargo@v1
         with:

--- a/Justfile
+++ b/Justfile
@@ -3,6 +3,10 @@ set shell := ["bash", "+u", "-c"]
 alias cov := coverage
 
 test:
+    if ! cargo test; then \
+        just test-clean; \
+        exit 1; \
+    fi
     if ! cargo test --features=notification,encryption,yubikey; then \
         just test-clean; \
         exit 1; \

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use crate::utils::callers::CurrentCaller;
 use crate::{debug, error, info, warn};
 use aes_gcm::aead::generic_array::{typenum, GenericArray};
 use anyhow::{anyhow, Context, Result};
-#[cfg(test)]
+#[cfg(all(test, feature = "yubikey"))]
 use mockall::automock;
 use serde::{de, Deserialize, Serialize};
 use std::cell::RefCell;
@@ -736,7 +736,7 @@ trait YubiKeyTrait {
     ) -> Result<Vec<u8>, YubicoError>;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "yubikey"))]
 impl MockYubiKeyTrait {
     fn new_mock() -> Self {
         use hmac::Mac;
@@ -833,14 +833,19 @@ mod tests {
     use super::*;
     use crate::keepassxc::Group;
     use crate::utils::generate_secret_key;
+    #[cfg(feature = "yubikey")]
     use hmac::Hmac;
+    #[cfg(feature = "yubikey")]
     use sha1::Sha1;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
+    #[cfg(feature = "yubikey")]
     pub type HmacSha1 = Hmac<Sha1>;
 
+    #[cfg(feature = "yubikey")]
     pub static TEST_YUBIKEY_SERIAL: u32 = 1234567;
+    #[cfg(feature = "yubikey")]
     pub static TEST_YUBIKEY_HMAC_SHA1_SECRET: &'static str = "test_secret";
 
     #[test]
@@ -882,6 +887,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "yubikey")]
     fn test_01_config_read_write_challenge_response() {
         let config_path = {
             let mut temp = std::env::temp_dir();
@@ -935,6 +941,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "yubikey")]
     fn test_02_ignore_plaintext_callers_when_there_are_encrypted_ones() {
         let config_path = {
             let mut temp = std::env::temp_dir();


### PR DESCRIPTION
The be honest this is a bit of a minimal effort PR.
After cloning the repo the first things I did were
```
cargo build
cargo test
```
It would be nice if `cargo test` would work without errors and warnings. Currently some tests fail if the `yubikey` feature is not enabled.