### PR TITLE
Adopt conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       release_id: ${{ steps.create_release.outputs.id }}
+      is_pre: ${{ steps.release_type.outputs.is_pre }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -29,12 +30,19 @@ jobs:
           echo 'CHANGELOG<<EOF' >> $GITHUB_ENV
           ./clog -F --setversion="$GITHUB_REF_NAME" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
+      - name: Determine release type
+        id: release_type
+        shell: bash
+        run: |
+          is_pre='false'
+          [[ "$GITHUB_REF_NAME" == *"-"* ]] && is_pre='true'
+          printf '::set-output name=is_pre::%s\n' "$is_pre"
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
         with:
           draft: true
-          prerelease: false
+          prerelease: ${{ steps.release_type.outputs.is_pre }}
           body: ${{ env.CHANGELOG }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -202,6 +210,7 @@ jobs:
   publish_release:
     runs-on: ubuntu-latest
     needs: [create_release, build]
+    if: ${{ needs.create_release.outputs.is_pre == 'false' }}
     steps:
       - name: Publish Release
         uses: eregon/publish-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,16 @@ jobs:
           curl -s -L -o./clog.tar.gz https://github.com/clog-tool/clog-cli/releases/download/v0.9.3/clog-v0.9.3-x86_64-unknown-linux-musl.tar.gz
           tar -xf ./clog.tar.gz
           chmod +x ./clog
-          # delete current tag locally so clog uses last tag as --from
+          # delete current tag locally
           git tag -d "$GITHUB_REF_NAME"
+          if [[ "$GITHUB_REF_NAME" == *"-"* ]]; then
+            last_tag="$(git tag -l --sort version:refname | tail -n1)"
+          else
+            last_tag="$(git tag -l --sort version:refname | grep -v -- - | tail -n1)"
+          fi
+          printf 'Using %s as last tag\n' "$last_tag"
           echo 'CHANGELOG<<EOF' >> $GITHUB_ENV
-          ./clog -F --setversion="$GITHUB_REF_NAME" >> $GITHUB_ENV
+          ./clog --from="$last_tag" --setversion="$GITHUB_REF_NAME" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: Determine release type
         id: release_type

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,27 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       release_id: ${{ steps.create_release.outputs.id }}
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Conventional Commit Changelog
+        id: conventional_commits
+        run: |
+          curl -s -L -o./clog.tar.gz https://github.com/clog-tool/clog-cli/releases/download/v0.9.3/clog-v0.9.3-x86_64-unknown-linux-musl.tar.gz
+          tar -xf ./clog.tar.gz
+          chmod +x ./clog
+          # delete current tag locally so clog uses last tag as --from
+          git tag -d "$GITHUB_REF_NAME"
+          echo 'CHANGELOG<<EOF' >> $GITHUB_ENV
+          ./clog -F --setversion="$GITHUB_REF_NAME" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
         with:
           draft: true
           prerelease: false
+          body: ${{ env.CHANGELOG }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
@@ -32,7 +47,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Git Commit Hash
         id: git_commit
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
             experimental: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Git Commit Hash
         id: git_commit
         run: |

--- a/Justfile
+++ b/Justfile
@@ -79,8 +79,11 @@ release version:
     set -e
     @if [[ "{{version}}" == v* ]]; then printf 'Must not have v-prefix\n'; exit 1; fi
     # changelog
-    clog -F --setversion=v{{version}} -o ./CHANGELOG.md
-    git add ./CHANGELOG.md
+    if [[ "{{version}}" != *"-"* ]]; then \
+        last_tag="$(git tag -l --sort version:refname | tail -n1)"; \
+        clog --from="$last_tag" --setversion=v{{version}} -o ./CHANGELOG.md; \
+        git add ./CHANGELOG.md; \
+    fi
     # lint, test, build
     sed 's/^version = ".*"$/version = "{{version}}"/' -i ./Cargo.toml
     just lint

--- a/Justfile
+++ b/Justfile
@@ -75,4 +75,22 @@ update:
     @printf 'Running cargo outdated\n'
     cargo outdated --features all -R
 
+release version:
+    set -e
+    @if [[ "{{version}}" == v* ]]; then printf 'Must not have v-prefix\n'; exit 1; fi
+    # changelog
+    clog -F --setversion=v{{version}} -o ./CHANGELOG.md
+    git add ./CHANGELOG.md
+    # lint, test, build
+    sed 's/^version = ".*"$/version = "{{version}}"/' -i ./Cargo.toml
+    just lint
+    just test
+    just build
+    git add ./Cargo.toml ./Cargo.lock
+    # commit and tag
+    git status
+    git diff --exit-code
+    git commit -m 'chore: Bump version to {{version}}'
+    git tag v{{version}}
+
 # vim: set filetype=just :

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -403,7 +403,7 @@ type NaClNonce = generic_array::GenericArray<u8, generic_array::typenum::U24>;
 pub fn nacl_nonce() -> (NaClNonce, String) {
     let mut rng = rand::thread_rng();
     let nonce = crypto_box::generate_nonce(&mut rng);
-    let nonce_b64 = base64::encode(&nonce);
+    let nonce_b64 = base64::encode(nonce);
     (nonce, nonce_b64)
 }
 


### PR DESCRIPTION
<!-- === GH HISTORY FENCE === -->
### bf967b350812185634c949d9153f772bd59a55ef ci: Adopt conventional commits

Add clog output to GitHub release description. Also a new `just release`
command to help with the release process.


### 7ccf54dd94ed9ed7cfd028707ee2c4932bea3693 ci: Publish draft prerelease if tag contains hyphen



### d3c8e1d0adb32adfddffcc2ed0ed67afd425fe2e improvement: Remove needless borrow

Got this on nightly. See [1].

[1] https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow


### 4074b0bf5cfa2370e0c408bdea410b16302a15c6 ci: Log from last formal version in formal releases

Also don't update CHANGELOG.md if it's a prerelease.


<!-- === GH HISTORY FENCE === -->
