### PR TITLE
ci: Use gh-ph to add commit history to PR bodies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+# Description
+
+# Changes
+<!-- === GH HISTORY FORMAT FENCE === --> <!--
+### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
+--> <!-- === GH HISTORY FORMAT FENCE === -->
+<!-- === GH HISTORY FENCE === -->
+<!-- Do NOT write here! -->
+<!-- It will be filled in by GitHub Actions automatically. -->
+<!-- === GH HISTORY FENCE === -->
+
+# Checklist
+
+- [ ] I have rebased my branch so that it has no conflicts
+- [ ] I have added tests where appropriate
+- [ ] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)
+
+<!---
+Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
+Omitted if the PR changes some shared functionalities.
+--->
+
+# Is this a breaking change?
+
+<!-- Yes / No. Reason. -->

--- a/.github/workflows/gh-ph.yml
+++ b/.github/workflows/gh-ph.yml
@@ -1,0 +1,16 @@
+name: Pull request history
+
+on:
+  pull_request:
+
+jobs:
+  gh-ph:
+    name: Add commit history to pull request description
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: Frederick888/gh-ph@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
<!-- Do NOT write here! -->
<!-- It will be filled in by GitHub Actions automatically. -->
<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
