### PR TITLE
build: macOS universal binary in GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Git Commit Hash
-        id: git_commit
-        run: |
-          echo "::set-output name=hash::$(git rev-parse HEAD)"
 
       - name: Install Linux Dependencies
         if: contains(matrix.os, 'ubuntu')
@@ -100,7 +96,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-git-${{ steps.git_commit.outputs.hash }}
+          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-git-${{ github.sha }}
           restore-keys: |
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,87 @@ jobs:
           body: ${{ env.CHANGELOG }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  lint:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        features: [default, all]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust Toolchain
+        id: rust_toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+          components: rustfmt, clippy
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
+          restore-keys: |
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
+            lint-${{ runner.os }}-
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features=${{ matrix.features }} --locked --tests -- -D warnings
+
+  test:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        features:
+          - [default]
+          - [all]
+          - [notification, encryption, yubikey]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust Toolchain
+        id: rust_toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-git-${{ github.sha }}
+          restore-keys: |
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
+            test-${{ runner.os }}-
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --features=${{ join(matrix.features) }}
+
   build:
     runs-on: ${{ matrix.os }}
     needs: create_release
@@ -59,6 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        features: [default, all]
 
     steps:
       - uses: actions/checkout@v3
@@ -82,7 +164,6 @@ jobs:
           toolchain: stable
           default: true
           override: true
-          components: rustfmt, clippy
       - name: Add macOS Targets
         if: contains(matrix.os, 'macos')
         run: |
@@ -96,165 +177,91 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-git-${{ github.sha }}
+          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
           restore-keys: |
+            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
             build-${{ runner.os }}-
 
-      - name: rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
-      - name: "Clippy (No Features)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --locked --tests -- -D warnings
-      - name: "Clippy (All Features)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features=all --locked --tests -- -D warnings
-
-      - name: "Test (No Features)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
-      - name: "Test (No strict-caller)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features=notification,encryption,yubikey
-      - name: "Test (All Features)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features=all
-
-      - name: "Build (No Features, Linux/Windows)"
+      - name: "Build (Linux/Windows)"
         if: "!contains(matrix.os, 'macos')"
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release
-      - name: "Build (No Features, macOS x86_64)"
+          args: --release --features=${{ matrix.features }}
+      - name: "Build (macOS x86_64)"
         if: contains(matrix.os, 'macos')
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target=x86_64-apple-darwin
-      - name: "Build (No Features, macOS aarch64)"
+          args: --release --features=${{ matrix.features }} --target=x86_64-apple-darwin
+      - name: "Build (macOS aarch64)"
         if: contains(matrix.os, 'macos')
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target=aarch64-apple-darwin
-      - name: macOS Universal Binary (No Features)
+          args: --release --features=${{ matrix.features }} --target=aarch64-apple-darwin
+      - name: macOS Universal Binary
         if: contains(matrix.os, 'macos')
         run: |
           mkdir -p target/release/
           lipo -create -output target/release/git-credential-keepassxc target/x86_64-apple-darwin/release/git-credential-keepassxc target/aarch64-apple-darwin/release/git-credential-keepassxc
           file target/release/git-credential-keepassxc
-      - name: "Pack (No Features)"
-        id: pack_minimal
+      - name: Determine artifact name suffix
+        id: artifact_suffix
+        if: "matrix.features == 'default' || matrix.features == 'all'"
+        shell: bash
         run: |
-          zip -j "./${{ matrix.os }}-minimal.zip" target/release/git-credential-keepassxc target/release/git-credential-keepassxc.exe
-          echo "::set-output name=filename::${{ matrix.os }}-minimal"
-      - name: "Hash (No Features, Unix)"
+          case "${{ matrix.features }}" in
+            default)
+              printf '::set-output name=suffix::%s\n' "minimal"
+              ;;
+            all)
+              printf '::set-output name=suffix::%s\n' "full"
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
+      - name: Pack
+        id: pack
+        run: |
+          zip -j "./${{ matrix.os }}-${{ steps.artifact_suffix.outputs.suffix }}.zip" target/release/git-credential-keepassxc target/release/git-credential-keepassxc.exe
+          echo "::set-output name=filename::${{ matrix.os }}-${{ steps.artifact_suffix.outputs.suffix }}"
+      - name: "Hash (Unix)"
         if: "!contains(matrix.os, 'windows')"
         run: |
-          echo "$(sha256sum ${{ steps.pack_minimal.outputs.filename }}.zip | cut -d ' ' -f 1)" > ${{ steps.pack_minimal.outputs.filename }}.zip.sha256sum
-          cat ${{ steps.pack_minimal.outputs.filename }}.zip.sha256sum
-      - name: "Hash (No Features, Windows)"
+          echo "$(sha256sum ${{ steps.pack.outputs.filename }}.zip | cut -d ' ' -f 1)" > ${{ steps.pack.outputs.filename }}.zip.sha256sum
+          cat ${{ steps.pack.outputs.filename }}.zip.sha256sum
+      - name: "Hash (Windows)"
         if: contains(matrix.os, 'windows')
         run: |
-          $FileHash=(certutil -hashfile ${{ steps.pack_minimal.outputs.filename }}.zip SHA256 | findstr /v hash | findstr /v SHA).replace(" ", "")
+          $FileHash=(certutil -hashfile ${{ steps.pack.outputs.filename }}.zip SHA256 | findstr /v hash | findstr /v SHA).replace(" ", "")
           echo "$FileHash"
-          echo "$FileHash" > ${{ steps.pack_minimal.outputs.filename }}.zip.sha256sum
-      - name: "Upload (No Features)"
+          echo "$FileHash" > ${{ steps.pack.outputs.filename }}.zip.sha256sum
+      - name: Upload
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ./${{ steps.pack_minimal.outputs.filename }}.zip
-          asset_name: ${{ steps.pack_minimal.outputs.filename }}.zip
+          asset_path: ./${{ steps.pack.outputs.filename }}.zip
+          asset_name: ${{ steps.pack.outputs.filename }}.zip
           asset_content_type: application/zip
-      - name: "Upload Hash (No Features)"
+      - name: Upload Hash
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ./${{ steps.pack_minimal.outputs.filename }}.zip.sha256sum
-          asset_name: ${{ steps.pack_minimal.outputs.filename }}.zip.sha256sum
-          asset_content_type: text/plain
-
-      - name: "Build (All Features, Linux/Windows)"
-        if: "!contains(matrix.os, 'macos')"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=all
-      - name: "Build (all, macOS x86_64)"
-        if: contains(matrix.os, 'macos')
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=all --target=x86_64-apple-darwin
-      - name: "Build (all, macOS aarch64)"
-        if: contains(matrix.os, 'macos')
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=all --target=aarch64-apple-darwin
-      - name: macOS Universal Binary (all)
-        if: contains(matrix.os, 'macos')
-        run: |
-          mkdir -p target/release/
-          lipo -create -output target/release/git-credential-keepassxc target/x86_64-apple-darwin/release/git-credential-keepassxc target/aarch64-apple-darwin/release/git-credential-keepassxc
-          file target/release/git-credential-keepassxc
-      - name: "Pack (All Features)"
-        id: pack_full
-        run: |
-          zip -j "./${{ matrix.os }}-full.zip" target/release/git-credential-keepassxc target/release/git-credential-keepassxc.exe
-          echo "::set-output name=filename::${{ matrix.os }}-full"
-      - name: "Hash (All Features, Unix)"
-        if: "!contains(matrix.os, 'windows')"
-        run: |
-          echo "$(sha256sum ${{ steps.pack_full.outputs.filename }}.zip | cut -d ' ' -f 1)" > ${{ steps.pack_full.outputs.filename }}.zip.sha256sum
-          cat ${{ steps.pack_full.outputs.filename }}.zip.sha256sum
-      - name: "Hash (All Features, Windows)"
-        if: contains(matrix.os, 'windows')
-        run: |
-          $FileHash=(certutil -hashfile ${{ steps.pack_full.outputs.filename }}.zip SHA256 | findstr /v hash | findstr /v SHA).replace(" ", "")
-          echo "$FileHash"
-          echo "$FileHash" > ${{ steps.pack_full.outputs.filename }}.zip.sha256sum
-      - name: "Upload (All Features)"
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ./${{ steps.pack_full.outputs.filename }}.zip
-          asset_name: ${{ steps.pack_full.outputs.filename }}.zip
-          asset_content_type: application/zip
-      - name: "Upload Hash (All Features)"
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ./${{ steps.pack_full.outputs.filename }}.zip.sha256sum
-          asset_name: ${{ steps.pack_full.outputs.filename }}.zip.sha256sum
+          asset_path: ./${{ steps.pack.outputs.filename }}.zip.sha256sum
+          asset_name: ${{ steps.pack.outputs.filename }}.zip.sha256sum
           asset_content_type: text/plain
 
   publish_release:
     runs-on: ubuntu-latest
-    needs: [create_release, build]
+    needs: [create_release, lint, test, build]
     if: ${{ needs.create_release.outputs.is_pre == 'false' }}
     steps:
       - name: Publish Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,11 @@ jobs:
           default: true
           override: true
           components: rustfmt, clippy
+      - name: Add macOS Targets
+        if: contains(matrix.os, 'macos')
+        run: |
+          rustup target add x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin
 
       - name: Cache
         uses: actions/cache@v2
@@ -133,11 +138,30 @@ jobs:
           command: test
           args: --release --features=all
 
-      - name: "Build (No Features)"
+      - name: "Build (No Features, Linux/Windows)"
+        if: "!contains(matrix.os, 'macos')"
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release
+      - name: "Build (No Features, macOS x86_64)"
+        if: contains(matrix.os, 'macos')
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target=x86_64-apple-darwin
+      - name: "Build (No Features, macOS aarch64)"
+        if: contains(matrix.os, 'macos')
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target=aarch64-apple-darwin
+      - name: macOS Universal Binary (No Features)
+        if: contains(matrix.os, 'macos')
+        run: |
+          mkdir -p target/release/
+          lipo -create -output target/release/git-credential-keepassxc target/x86_64-apple-darwin/release/git-credential-keepassxc target/aarch64-apple-darwin/release/git-credential-keepassxc
+          file target/release/git-credential-keepassxc
       - name: "Pack (No Features)"
         id: pack_minimal
         run: |
@@ -173,11 +197,30 @@ jobs:
           asset_name: ${{ steps.pack_minimal.outputs.filename }}.zip.sha256sum
           asset_content_type: text/plain
 
-      - name: "Build (All Features)"
+      - name: "Build (All Features, Linux/Windows)"
+        if: "!contains(matrix.os, 'macos')"
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --features=all
+      - name: "Build (all, macOS x86_64)"
+        if: contains(matrix.os, 'macos')
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --features=all --target=x86_64-apple-darwin
+      - name: "Build (all, macOS aarch64)"
+        if: contains(matrix.os, 'macos')
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --features=all --target=aarch64-apple-darwin
+      - name: macOS Universal Binary (all)
+        if: contains(matrix.os, 'macos')
+        run: |
+          mkdir -p target/release/
+          lipo -create -output target/release/git-credential-keepassxc target/x86_64-apple-darwin/release/git-credential-keepassxc target/aarch64-apple-darwin/release/git-credential-keepassxc
+          file target/release/git-credential-keepassxc
       - name: "Pack (All Features)"
         id: pack_full
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,10 +34,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Git Commit Hash
-        id: git_commit
-        run: |
-          echo "::set-output name=hash::$(git rev-parse HEAD)"
 
       - name: Cancel Previous Runs
         if: contains(matrix.os, 'ubuntu')
@@ -75,7 +71,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-git-${{ steps.git_commit.outputs.hash }}
+          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-git-${{ github.sha }}
           restore-keys: |
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,11 @@ jobs:
           default: true
           override: true
           components: rustfmt, clippy
+      - name: Add macOS Targets
+        if: contains(matrix.os, 'macos')
+        run: |
+          rustup target add x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin
 
       - name: Cache
         uses: actions/cache@v2
@@ -92,11 +97,30 @@ jobs:
           command: clippy
           args: --features=all --locked --tests -- -D warnings
 
-      - name: "Build (No Features)"
+      - name: "Build (No Features, Linux/Windows)"
+        if: "!contains(matrix.os, 'macos')"
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release
+      - name: "Build (No Features, macOS x86_64)"
+        if: contains(matrix.os, 'macos')
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target=x86_64-apple-darwin
+      - name: "Build (No Features, macOS aarch64)"
+        if: contains(matrix.os, 'macos')
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target=aarch64-apple-darwin
+      - name: macOS Universal Binary (No Features)
+        if: contains(matrix.os, 'macos')
+        run: |
+          mkdir -p target/release/
+          lipo -create -output target/release/git-credential-keepassxc target/x86_64-apple-darwin/release/git-credential-keepassxc target/aarch64-apple-darwin/release/git-credential-keepassxc
+          file target/release/git-credential-keepassxc
       - name: "Artifacts (No Features)"
         uses: actions/upload-artifact@v2
         with:
@@ -120,11 +144,30 @@ jobs:
         with:
           command: build
           args: --release --features=yubikey
-      - name: "Build (all)"
+      - name: "Build (all, Linux/Windows)"
+        if: "!contains(matrix.os, 'macos')"
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --features=all
+      - name: "Build (all, macOS x86_64)"
+        if: contains(matrix.os, 'macos')
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --features=all --target=x86_64-apple-darwin
+      - name: "Build (all, macOS aarch64)"
+        if: contains(matrix.os, 'macos')
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --features=all --target=aarch64-apple-darwin
+      - name: macOS Universal Binary (all)
+        if: contains(matrix.os, 'macos')
+        run: |
+          mkdir -p target/release/
+          lipo -create -output target/release/git-credential-keepassxc target/x86_64-apple-darwin/release/git-credential-keepassxc target/aarch64-apple-darwin/release/git-credential-keepassxc
+          file target/release/git-credential-keepassxc
       - name: "Artifacts (All Features)"
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,111 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  cancel_previous:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.10.0
+        with:
+          access_token: ${{ github.token }}
+
+  lint:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust_toolchain: [stable]
+        features: [default, all]
+        experimental: [false]
+        include:
+          - os: ubuntu-latest
+            rust_toolchain: nightly
+            features: all
+            experimental: true
+          - os: macos-latest
+            rust_toolchain: nightly
+            features: all
+            experimental: true
+          - os: windows-latest
+            rust_toolchain: nightly
+            features: all
+            experimental: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust Toolchain
+        id: rust_toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust_toolchain }}
+          default: true
+          override: true
+          components: rustfmt, clippy
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
+          restore-keys: |
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
+            lint-${{ runner.os }}-
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features=${{ matrix.features }} --locked --tests -- -D warnings
+
+  test:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust_toolchain: [stable]
+        features:
+          - [default]
+          - [all]
+          - [notification, encryption, yubikey]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust Toolchain
+        id: rust_toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust_toolchain }}
+          default: true
+          override: true
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-git-${{ github.sha }}
+          restore-keys: |
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
+            test-${{ runner.os }}-
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --features=${{ join(matrix.features) }}
+
   build:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
@@ -20,27 +125,23 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust_toolchain: [stable]
+        features: [default, notification, yubikey, all]
         experimental: [false]
         include:
           - os: ubuntu-latest
             rust_toolchain: nightly
+            features: all
             experimental: true
           - os: macos-latest
             rust_toolchain: nightly
+            features: all
             experimental: true
           - os: windows-latest
             rust_toolchain: nightly
+            features: all
             experimental: true
-
     steps:
       - uses: actions/checkout@v3
-
-      - name: Cancel Previous Runs
-        if: contains(matrix.os, 'ubuntu')
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Install Linux Dependencies
         if: contains(matrix.os, 'ubuntu')
         run: sudo apt-get install -y libusb-1.0-0 libusb-1.0-0-dev libdbus-1-dev
@@ -57,7 +158,6 @@ jobs:
           toolchain: ${{ matrix.rust_toolchain }}
           default: true
           override: true
-          components: rustfmt, clippy
       - name: Add macOS Targets
         if: contains(matrix.os, 'macos')
         run: |
@@ -65,126 +165,66 @@ jobs:
           rustup target add aarch64-apple-darwin
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-git-${{ github.sha }}
+          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
           restore-keys: |
+            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
             build-${{ runner.os }}-
 
-      - name: rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
-      - name: "Clippy (No Features)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --locked --tests -- -D warnings
-      - name: "Clippy (All Features)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features=all --locked --tests -- -D warnings
-
-      - name: "Build (No Features, Linux/Windows)"
+      - name: "Build (Linux/Windows)"
         if: "!contains(matrix.os, 'macos')"
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release
-      - name: "Build (No Features, macOS x86_64)"
+          args: --release --features=${{ matrix.features }}
+      - name: "Build (macOS x86_64)"
         if: contains(matrix.os, 'macos')
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target=x86_64-apple-darwin
-      - name: "Build (No Features, macOS aarch64)"
+          args: --release --features=${{ matrix.features }} --target=x86_64-apple-darwin
+      - name: "Build (macOS aarch64)"
         if: contains(matrix.os, 'macos')
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target=aarch64-apple-darwin
-      - name: macOS Universal Binary (No Features)
+          args: --release --features=${{ matrix.features }} --target=aarch64-apple-darwin
+      - name: macOS Universal Binary
         if: contains(matrix.os, 'macos')
         run: |
           mkdir -p target/release/
           lipo -create -output target/release/git-credential-keepassxc target/x86_64-apple-darwin/release/git-credential-keepassxc target/aarch64-apple-darwin/release/git-credential-keepassxc
           file target/release/git-credential-keepassxc
-      - name: "Artifacts (No Features)"
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.os }}-${{ matrix.rust_toolchain }}-minimal
-          retention-days: 60
-          path: |
-            target/release/git-credential-keepassxc
-            target/release/git-credential-keepassxc.exe
-      - name: "Build (notification)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=notification
-      - name: "Build (encryption)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=encryption
-      - name: "Build (yubikey)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=yubikey
-      - name: "Build (all, Linux/Windows)"
-        if: "!contains(matrix.os, 'macos')"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=all
-      - name: "Build (all, macOS x86_64)"
-        if: contains(matrix.os, 'macos')
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=all --target=x86_64-apple-darwin
-      - name: "Build (all, macOS aarch64)"
-        if: contains(matrix.os, 'macos')
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=all --target=aarch64-apple-darwin
-      - name: macOS Universal Binary (all)
-        if: contains(matrix.os, 'macos')
-        run: |
-          mkdir -p target/release/
-          lipo -create -output target/release/git-credential-keepassxc target/x86_64-apple-darwin/release/git-credential-keepassxc target/aarch64-apple-darwin/release/git-credential-keepassxc
-          file target/release/git-credential-keepassxc
-      - name: "Artifacts (All Features)"
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.os }}-${{ matrix.rust_toolchain }}-full
-          retention-days: 60
-          path: |
-            target/release/git-credential-keepassxc
-            target/release/git-credential-keepassxc.exe
 
-      - name: "Test (No Features)"
-        uses: actions-rs/cargo@v1
+      - name: Determine artifact name suffix
+        id: artifact_suffix
+        if: "matrix.features == 'default' || matrix.features == 'all'"
+        shell: bash
+        run: |
+          case "${{ matrix.features }}" in
+            default)
+              printf '::set-output name=suffix::%s\n' "minimal"
+              ;;
+            all)
+              printf '::set-output name=suffix::%s\n' "full"
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
+      - name: Artifacts
+        if: "matrix.features == 'default' || matrix.features == 'all'"
+        uses: actions/upload-artifact@v3
         with:
-          command: test
-          args: --release
-      - name: "Test (No strict-caller)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features=notification,encryption,yubikey
-      - name: "Test (All Features)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features=all
+          name: ${{ matrix.os }}-${{ matrix.rust_toolchain }}-${{ steps.artifact_suffix.outputs.suffix }}
+          retention-days: 60
+          path: |
+            target/release/git-credential-keepassxc
+            target/release/git-credential-keepassxc.exe


### PR DESCRIPTION
# Description

Build macOS universal binaries for x86_64 and aarch64.

# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`1428b19`](https://github.com/Frederick888/git-credential-keepassxc/pull/46/commits/1428b19b5fcb74c58b9e957a262afbd8edbc816e) build: macOS universal binary in GitHub Actions



### [`0810c78`](https://github.com/Frederick888/git-credential-keepassxc/pull/46/commits/0810c7860e69eab58c02c3b58f621a2baf676857) ci: Use github.sha as commit hash



### [`201090e`](https://github.com/Frederick888/git-credential-keepassxc/pull/46/commits/201090e0f5579d9fbd8582929f6bfd06cff9a79e) ci: More parallel GitHub Actions jobs



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->

No.
