### PR TITLE
Group filter and Git detection

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,10 +18,19 @@ pub struct MainArgs {
     /// Specify KeePassXC socket path (environment variable: KEEPASSXC_BROWSER_SOCKET_PATH)
     #[clap(short, long, value_parser)]
     pub socket: Option<String>,
-    /// Try unlocking database, applies to get, store and erase only.
+    /// Try unlocking database. Applies to get and store only.
     /// Takes one argument in the format of [<MAX_RETRIES>[,<INTERVAL_MS>]]. Use 0 to retry indefinitely. The default interval is 1000ms.
     #[clap(long, value_parser, verbatim_doc_comment)]
     pub unlock: Option<UnlockOptions>,
+    /// Do not filter out entries with advanced field 'KPH: git' set to false. Applies to get and store only
+    #[clap(long, value_parser, global = true)]
+    pub no_filter: bool,
+    /// Do not try using entries from dedicated group only for HTTP Git operations. Applies to get and store only
+    #[clap(long, value_parser, global = true)]
+    pub no_git_detection: bool,
+    /// Use specified KeePassXC group only, overrides Git detection. Applies to get and store only
+    #[clap(long, value_parser, global = true)]
+    pub group: Option<String>,
     /// Sets the level of verbosity (-v: WARNING; -vv: INFO; -vvv: DEBUG in debug builds)
     #[clap(short, action(ArgAction::Count))]
     pub verbose: u8,

--- a/src/git.rs
+++ b/src/git.rs
@@ -156,6 +156,18 @@ impl GitCredentialMessage {
             ))
         }
     }
+
+    pub fn is_http(&self) -> bool {
+        if let Some(protocol) = &self.protocol {
+            let protocol = protocol.to_ascii_lowercase();
+            return protocol == "http" || protocol == "https";
+        }
+        if let Some(url) = &self.url {
+            let url = url.to_ascii_lowercase();
+            return url.starts_with("http://") || url.starts_with("https://");
+        }
+        false
+    }
 }
 
 #[cfg(test)]
@@ -197,5 +209,16 @@ mod tests {
             .collect();
         message.set_string_fields(&advanced_fields);
         assert_eq!(string1 + &string2 + "\n", message.to_string());
+    }
+
+    #[test]
+    fn test_03_is_http() {
+        let string = "url=https://example.com\n".to_owned();
+        let message = GitCredentialMessage::from_str(string.as_str()).unwrap();
+        assert!(message.is_http());
+
+        let string = "protocol=http\nhost=example.com\n".to_owned();
+        let message = GitCredentialMessage::from_str(string.as_str()).unwrap();
+        assert!(message.is_http());
     }
 }

--- a/src/keepassxc/messages/structs.rs
+++ b/src/keepassxc/messages/structs.rs
@@ -446,6 +446,7 @@ impl GetLoginsRequest {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct LoginEntry {
+    pub group: String,
     pub login: String,
     pub name: String,
     pub password: String,


### PR DESCRIPTION
# Description

Closes #50

Detect Git HTTP operations (mainly fetch/push over HTTP/S) and use
entries from git-credentials-keepassxc group (configured during
`git-credentials-keepassxc configure`, by default `Git`).

Also offers a `--group xyz` option for get/set.

# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`7065583`](https://github.com/Frederick888/git-credential-keepassxc/pull/51/commits/706558352688d4a47c1793b80b6bce10e7cba217) refactor: Move GitCredentialMessage ops to impl



### [`296efde`](https://github.com/Frederick888/git-credential-keepassxc/pull/51/commits/296efde484541b8ff552ba512f1b0090a22bd31c) feat(get,store)!: Group filter from CLI or Git detection

When Git is requesting an HTTP/S credential, by default only return
entries from the dedicated group configured by `git-credential-keepassxc
configure`. This can be disabled by `--no-git-detection`.

Note since KeePassXC returns no database info here, group names
configured for all databases are used regardless of where an entry is
from. So it's better to simply use the same dedicated group name across
the board (by default this is 'Git').

Also implements `--group`. This option overrides Git detection.

Requires KeePassXC >= 2.6.0 [1].

[1] https://github.com/keepassxreboot/keepassxc/pull/4111


### [`5dfdde1`](https://github.com/Frederick888/git-credential-keepassxc/pull/51/commits/5dfdde1856f7b4fa385c9039962626ef6d778651) feat(get,store): Global filter options

Allow using --no-filter/--no-git-detection/--group in front of
get/store. This can come handy if someone wants to use them in
.gitconfig, as Git places these options in front of subcommands and
there is no longer a need to write a custom wrapper.

Note conflicts_with = "<subcommand option>" does not work when using
these filter options at global position.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
Yes. If someone's been using a credential from other groups for such
operations, it'll break cos we now return from the dedicated group only
by default.
