### PR TITLE
ci: Replace Actions set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
           fetch-depth: 0
       - name: Conventional Commit Changelog
         id: conventional_commits
+        shell: bash
         run: |
           curl -s -L -o./clog.tar.gz https://github.com/clog-tool/clog-cli/releases/download/v0.9.3/clog-v0.9.3-x86_64-unknown-linux-musl.tar.gz
           tar -xf ./clog.tar.gz
@@ -42,7 +43,7 @@ jobs:
         run: |
           is_pre='false'
           [[ "$GITHUB_REF_NAME" == *"-"* ]] && is_pre='true'
-          printf '::set-output name=is_pre::%s\n' "$is_pre"
+          printf 'is_pre=%s\n' "$is_pre" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
@@ -64,11 +65,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust Toolchain
         id: rust_toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          default: true
-          override: true
           components: rustfmt, clippy
       - name: Cache
         uses: actions/cache@v3
@@ -77,22 +76,20 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
+          key: lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
           restore-keys: |
-            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
-            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
-            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-
             lint-${{ runner.os }}-
       - name: rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        shell: bash
+        run: |
+          cargo fmt -- --check
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features=${{ matrix.features }} --locked --tests -- -D warnings
+        shell: bash
+        run: |
+          cargo clippy --features=${{ matrix.features }} --locked --tests -- -D warnings
 
   test:
     runs-on: ${{ matrix.os }}
@@ -109,11 +106,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust Toolchain
         id: rust_toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          default: true
-          override: true
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -121,17 +116,16 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-git-${{ github.sha }}
+          key: test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-git-${{ github.sha }}
           restore-keys: |
-            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-
-            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
-            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-
             test-${{ runner.os }}-
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features=${{ join(matrix.features) }}
+        shell: bash
+        run: |
+          cargo test --release --features=${{ join(matrix.features) }}
 
   build:
     runs-on: ${{ matrix.os }}
@@ -159,11 +153,9 @@ jobs:
 
       - name: Install Rust Toolchain
         id: rust_toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          default: true
-          override: true
       - name: Add macOS Targets
         if: contains(matrix.os, 'macos')
         run: |
@@ -171,37 +163,34 @@ jobs:
           rustup target add aarch64-apple-darwin
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
+          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
           restore-keys: |
-            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
-            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
-            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
+            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
+            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-
+            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-
             build-${{ runner.os }}-
 
       - name: "Build (Linux/Windows)"
         if: "!contains(matrix.os, 'macos')"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=${{ matrix.features }}
+        shell: bash
+        run: |
+          cargo build --release --features=${{ matrix.features }}
       - name: "Build (macOS x86_64)"
         if: contains(matrix.os, 'macos')
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=${{ matrix.features }} --target=x86_64-apple-darwin
+        shell: bash
+        run: |
+          cargo build --release --features=${{ matrix.features }} --target=x86_64-apple-darwin
       - name: "Build (macOS aarch64)"
         if: contains(matrix.os, 'macos')
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=${{ matrix.features }} --target=aarch64-apple-darwin
+        shell: bash
+        run: |
+          cargo build --release --features=${{ matrix.features }} --target=aarch64-apple-darwin
       - name: macOS Universal Binary
         if: contains(matrix.os, 'macos')
         run: |
@@ -215,10 +204,10 @@ jobs:
         run: |
           case "${{ matrix.features }}" in
             default)
-              printf '::set-output name=suffix::%s\n' "minimal"
+              printf 'suffix=%s\n' 'minimal' >> $GITHUB_OUTPUT
               ;;
             all)
-              printf '::set-output name=suffix::%s\n' "full"
+              printf 'suffix=%s\n' 'full' >> $GITHUB_OUTPUT
               ;;
             *)
               exit 1
@@ -226,9 +215,10 @@ jobs:
           esac
       - name: Pack
         id: pack
+        shell: bash
         run: |
           zip -j "./${{ matrix.os }}-${{ steps.artifact_suffix.outputs.suffix }}.zip" target/release/git-credential-keepassxc target/release/git-credential-keepassxc.exe
-          echo "::set-output name=filename::${{ matrix.os }}-${{ steps.artifact_suffix.outputs.suffix }}"
+          echo "filename=${{ matrix.os }}-${{ steps.artifact_suffix.outputs.suffix }}" >> $GITHUB_OUTPUT
       - name: "Hash (Unix)"
         if: "!contains(matrix.os, 'windows')"
         run: |
@@ -241,18 +231,14 @@ jobs:
           echo "$FileHash"
           echo "$FileHash" > ${{ steps.pack.outputs.filename }}.zip.sha256sum
       - name: Upload
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: shogo82148/actions-upload-release-asset@v1
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: ./${{ steps.pack.outputs.filename }}.zip
           asset_name: ${{ steps.pack.outputs.filename }}.zip
           asset_content_type: application/zip
       - name: Upload Hash
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: shogo82148/actions-upload-release-asset@v1
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: ./${{ steps.pack.outputs.filename }}.zip.sha256sum

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 
@@ -47,11 +47,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust Toolchain
         id: rust_toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_toolchain }}
-          default: true
-          override: true
           components: rustfmt, clippy
       - name: Cache
         uses: actions/cache@v3
@@ -60,22 +58,20 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
+          key: lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
           restore-keys: |
-            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
-            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
-            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-
+            lint-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-
             lint-${{ runner.os }}-
       - name: rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        shell: bash
+        run: |
+          cargo fmt -- --check
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features=${{ matrix.features }} --locked --tests -- -D warnings
+        shell: bash
+        run: |
+          cargo clippy --features=${{ matrix.features }} --locked --tests -- -D warnings
 
   test:
     runs-on: ${{ matrix.os }}
@@ -93,11 +89,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust Toolchain
         id: rust_toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_toolchain }}
-          default: true
-          override: true
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -105,17 +99,16 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-git-${{ github.sha }}
+          key: test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-git-${{ github.sha }}
           restore-keys: |
-            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-
-            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
-            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ join(matrix.features, '+') }}-
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-
+            test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-
             test-${{ runner.os }}-
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features=${{ join(matrix.features) }}
+        shell: bash
+        run: |
+          cargo test --release --features=${{ join(matrix.features) }}
 
   build:
     runs-on: ${{ matrix.os }}
@@ -153,11 +146,9 @@ jobs:
 
       - name: Install Rust Toolchain
         id: rust_toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_toolchain }}
-          default: true
-          override: true
       - name: Add macOS Targets
         if: contains(matrix.os, 'macos')
         run: |
@@ -171,31 +162,28 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
+          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-git-${{ github.sha }}
           restore-keys: |
-            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
-            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-lock-${{ hashFiles('Cargo.lock') }}-
-            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.rustc_hash }}-
+            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-features-${{ matrix.features }}-
+            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-lock-${{ hashFiles('Cargo.lock') }}-
+            build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-
             build-${{ runner.os }}-
 
       - name: "Build (Linux/Windows)"
         if: "!contains(matrix.os, 'macos')"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=${{ matrix.features }}
+        shell: bash
+        run: |
+          cargo build --release --features=${{ matrix.features }}
       - name: "Build (macOS x86_64)"
         if: contains(matrix.os, 'macos')
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=${{ matrix.features }} --target=x86_64-apple-darwin
+        shell: bash
+        run: |
+          cargo build --release --features=${{ matrix.features }} --target=x86_64-apple-darwin
       - name: "Build (macOS aarch64)"
         if: contains(matrix.os, 'macos')
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=${{ matrix.features }} --target=aarch64-apple-darwin
+        shell: bash
+        run: |
+          cargo build --release --features=${{ matrix.features }} --target=aarch64-apple-darwin
       - name: macOS Universal Binary
         if: contains(matrix.os, 'macos')
         run: |
@@ -210,10 +198,10 @@ jobs:
         run: |
           case "${{ matrix.features }}" in
             default)
-              printf '::set-output name=suffix::%s\n' "minimal"
+              printf 'suffix=%s\n' 'minimal' >> $GITHUB_OUTPUT
               ;;
             all)
-              printf '::set-output name=suffix::%s\n' "full"
+              printf 'suffix=%s\n' 'full' >> $GITHUB_OUTPUT
               ;;
             *)
               exit 1


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`62dc4e0`](https://github.com/Frederick888/git-credential-keepassxc/pull/52/commits/62dc4e0ee9dc19097ae62d84db2c3984009eb516) ci: Replace Actions set-output with $GITHUB_OUTPUT

[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
