### PR TITLE
Refactor get_socket_path() and support KPXC 2.7.4 for Flatpak

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -880,10 +880,7 @@ fn real_main() -> Result<()> {
     };
     if let Some(path) = args.socket {
         info!("Socket path is set to {} by user", path);
-        let path = PathBuf::from(path);
-        utils::SOCKET_PATH.with(|s| {
-            s.set(path).expect("Failed to set socket path, bug?");
-        });
+        env::set_var(utils::socket::KEEPASS_SOCKET_ENVIRONMENT_VARIABLE, &path);
     };
     if let Some(ref unlock_options) = args.unlock {
         info!(

--- a/src/utils/socket.rs
+++ b/src/utils/socket.rs
@@ -22,6 +22,7 @@ pub fn get_socket_path() -> Result<PathBuf> {
         Box::new(LinuxSocketPath260),
         Box::new(MacSocketPath260),
         Box::new(WindowsSocketPath260),
+        Box::new(LinuxSocketPath274),
         Box::new(WindowsSocketPath262),
         Box::new(WindowsSocketPathNatMsg),
     ];
@@ -74,6 +75,26 @@ impl SocketPath for LinuxSocketPath260 {
         let result = base_dirs
             .runtime_dir()
             .ok_or_else(|| anyhow!("Failed to locate runtime_dir automatically"))?
+            .join(KEEPASS_SOCKET_NAME);
+        exist_or_error(result)
+    }
+
+    fn matches_os(&self) -> bool {
+        cfg!(target_os = "linux")
+    }
+}
+
+// https://github.com/keepassxreboot/keepassxc/commit/1009650b5c2697f5420c0f4398271652a4158c1a
+struct LinuxSocketPath274;
+impl SocketPath for LinuxSocketPath274 {
+    fn get_path(&self) -> Result<PathBuf> {
+        let base_dirs = directories_next::BaseDirs::new()
+            .ok_or_else(|| anyhow!("Failed to initialise base_dirs"))?;
+        let result = base_dirs
+            .runtime_dir()
+            .ok_or_else(|| anyhow!("Failed to locate runtime_dir automatically"))?
+            .join("app")
+            .join("org.keepassxc.KeePassXC")
             .join(KEEPASS_SOCKET_NAME);
         exist_or_error(result)
     }

--- a/src/utils/socket.rs
+++ b/src/utils/socket.rs
@@ -1,0 +1,210 @@
+use crate::{debug, info};
+use anyhow::{anyhow, Result};
+use std::{env, io, path::PathBuf};
+
+pub const KEEPASS_SOCKET_ENVIRONMENT_VARIABLE: &str = "KEEPASSXC_BROWSER_SOCKET_PATH";
+
+#[cfg(windows)]
+const NAMED_PIPE_CONNECT_TIMEOUT_MS: u32 = 100;
+const KEEPASS_SOCKET_NAME: &str = "org.keepassxc.KeePassXC.BrowserServer";
+// socket name prior to KeePassXC 2.6.0
+const KEEPASS_SOCKET_NAME_LEGACY: &str = "kpxc_server";
+
+pub fn get_socket_path() -> Result<PathBuf> {
+    if let Ok(env_socket_path) = env::var(KEEPASS_SOCKET_ENVIRONMENT_VARIABLE) {
+        return Ok(PathBuf::from(env_socket_path));
+    }
+
+    let candidates: Vec<Box<dyn SocketPath>> = vec![
+        Box::new(LinuxSocketPathLegacy),
+        Box::new(MacSocketPathLegacy),
+        Box::new(WindowsSocketPathLegacy),
+        Box::new(LinuxSocketPath260),
+        Box::new(MacSocketPath260),
+        Box::new(WindowsSocketPath260),
+        Box::new(WindowsSocketPath262),
+        Box::new(WindowsSocketPathNatMsg),
+    ];
+    let winner = candidates
+        .iter()
+        .filter(|c| c.matches_os())
+        .find_map(|c| match c.get_path() {
+            Ok(path) => Some(path),
+            Err(e) => {
+                debug!("Unqualified socket path candidate: {:?}", e);
+                None
+            }
+        });
+    match winner {
+        Some(winner) => {
+            info!("Socket path: {}", winner.to_string_lossy());
+            Ok(winner)
+        }
+        None => Err(anyhow!("Failed to locate socket")),
+    }
+}
+
+trait SocketPath {
+    fn get_path(&self) -> Result<PathBuf>;
+    fn matches_os(&self) -> bool;
+}
+
+struct LinuxSocketPathLegacy;
+impl SocketPath for LinuxSocketPathLegacy {
+    fn get_path(&self) -> Result<PathBuf> {
+        let base_dirs = directories_next::BaseDirs::new()
+            .ok_or_else(|| anyhow!("Failed to initialise base_dirs"))?;
+        let result = base_dirs
+            .runtime_dir()
+            .ok_or_else(|| anyhow!("Failed to locate runtime_dir automatically"))?
+            .join(KEEPASS_SOCKET_NAME_LEGACY);
+        exist_or_error(result)
+    }
+
+    fn matches_os(&self) -> bool {
+        cfg!(target_os = "linux")
+    }
+}
+
+struct LinuxSocketPath260;
+impl SocketPath for LinuxSocketPath260 {
+    fn get_path(&self) -> Result<PathBuf> {
+        let base_dirs = directories_next::BaseDirs::new()
+            .ok_or_else(|| anyhow!("Failed to initialise base_dirs"))?;
+        let result = base_dirs
+            .runtime_dir()
+            .ok_or_else(|| anyhow!("Failed to locate runtime_dir automatically"))?
+            .join(KEEPASS_SOCKET_NAME);
+        exist_or_error(result)
+    }
+
+    fn matches_os(&self) -> bool {
+        cfg!(target_os = "linux")
+    }
+}
+
+struct MacSocketPathLegacy;
+impl SocketPath for MacSocketPathLegacy {
+    fn get_path(&self) -> Result<PathBuf> {
+        let result = std::env::temp_dir().join(KEEPASS_SOCKET_NAME_LEGACY);
+        exist_or_error(result)
+    }
+
+    fn matches_os(&self) -> bool {
+        cfg!(target_os = "macos")
+    }
+}
+
+struct MacSocketPath260;
+impl SocketPath for MacSocketPath260 {
+    fn get_path(&self) -> Result<PathBuf> {
+        let result = std::env::temp_dir().join(KEEPASS_SOCKET_NAME);
+        exist_or_error(result)
+    }
+
+    fn matches_os(&self) -> bool {
+        cfg!(target_os = "macos")
+    }
+}
+
+struct WindowsSocketPathLegacy;
+impl SocketPath for WindowsSocketPathLegacy {
+    #[cfg(not(target_os = "windows"))]
+    fn get_path(&self) -> Result<PathBuf> {
+        unreachable!("Resolving WindowsSocketPathLegacy under non-Windows system");
+    }
+
+    #[cfg(target_os = "windows")]
+    fn get_path(&self) -> Result<PathBuf> {
+        let temp_dir = std::env::temp_dir();
+        let temp_dir = std::fs::canonicalize(temp_dir)?;
+        let result = PathBuf::from(format!(
+            r#"\\.\pipe\\{}\{}"#,
+            &temp_dir.to_string_lossy()[4..],
+            KEEPASS_SOCKET_NAME_LEGACY
+        ));
+        connectable_or_error(result)
+    }
+
+    fn matches_os(&self) -> bool {
+        cfg!(target_os = "windows")
+    }
+}
+
+// https://github.com/Frederick888/git-credential-keepassxc/pull/34
+struct WindowsSocketPathNatMsg;
+impl SocketPath for WindowsSocketPathNatMsg {
+    #[cfg(not(target_os = "windows"))]
+    fn get_path(&self) -> Result<PathBuf> {
+        unreachable!("Resolving WindowsSocketPathNatMsg under non-Windows system");
+    }
+
+    #[cfg(target_os = "windows")]
+    fn get_path(&self) -> Result<PathBuf> {
+        let username = std::env::var("USERNAME")?;
+        let result =
+            PathBuf::from(r#"\\.\pipe\keepassxc\"#.to_owned() + &username + r#"\kpxc_server"#);
+        connectable_or_error(result)
+    }
+
+    fn matches_os(&self) -> bool {
+        cfg!(target_os = "windows")
+    }
+}
+
+struct WindowsSocketPath260;
+impl SocketPath for WindowsSocketPath260 {
+    #[cfg(not(target_os = "windows"))]
+    fn get_path(&self) -> Result<PathBuf> {
+        unreachable!("Resolving WindowsSocketPath260 under non-Windows system");
+    }
+
+    #[cfg(target_os = "windows")]
+    fn get_path(&self) -> Result<PathBuf> {
+        let result = PathBuf::from(format!(r#"\\.\pipe\{}"#, KEEPASS_SOCKET_NAME));
+        connectable_or_error(result)
+    }
+
+    fn matches_os(&self) -> bool {
+        cfg!(target_os = "windows")
+    }
+}
+
+struct WindowsSocketPath262;
+impl SocketPath for WindowsSocketPath262 {
+    #[cfg(not(target_os = "windows"))]
+    fn get_path(&self) -> Result<PathBuf> {
+        unreachable!("Resolving WindowsSocketPath260 under non-Windows system");
+    }
+
+    #[cfg(target_os = "windows")]
+    fn get_path(&self) -> Result<PathBuf> {
+        let pipe_with_username = KEEPASS_SOCKET_NAME.to_owned() + "_" + &std::env::var("USERNAME")?;
+        let result = PathBuf::from(format!(r#"\\.\pipe\{}"#, pipe_with_username));
+        connectable_or_error(result)
+    }
+
+    fn matches_os(&self) -> bool {
+        cfg!(target_os = "windows")
+    }
+}
+
+fn exist_or_error(path: PathBuf) -> Result<PathBuf> {
+    if path.exists() {
+        Ok(path)
+    } else {
+        Err(anyhow!(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("{} does not exist", path.to_string_lossy()),
+        )))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn connectable_or_error(path: PathBuf) -> Result<PathBuf> {
+    let path = exist_or_error(path)?;
+    match named_pipe::PipeClient::connect_ms(&path, NAMED_PIPE_CONNECT_TIMEOUT_MS) {
+        Ok(_) => Ok(path),
+        Err(e) => Err(anyhow!(e)),
+    }
+}


### PR DESCRIPTION
# Description

Fixes #53

# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`4436b22`](https://github.com/Frederick888/git-credential-keepassxc/pull/55/commits/4436b22b2cd1a481c04cbb4132981f856f076603) refactor: Separate socket path logic for OSes/KPXC versions

Breaks down the very convoluted get_socket_path() into smaller pieces,
each taking care of a specific OS and KeePassXC (or KeePass 2)
combination.

Also instead of using a OnceCell to cater for the command line argument,
pass it along using an environment variable. There is no need to cache
this result anyway since it's only called by get_stream(). This should
fall into place nicely in terms of their priority as well.


### [`7356fc8`](https://github.com/Frederick888/git-credential-keepassxc/pull/55/commits/7356fc8021bae1596b41105209dee86c44783a9a) feat: Support socket path of KPXC 2.7.4 Flatpak

To avoiding mounting everything into Flatpak sandbox, the socket was
moved into a separate path under Linux [1][2].

Note this does not affect other distributions under Linux as there is a
symbolic link from the old path [3].

[1] https://github.com/keepassxreboot/keepassxc/pull/8030
[2] https://github.com/keepassxreboot/keepassxc/commit/1009650b5c2697f5420c0f4398271652a4158c1a
[3] https://github.com/keepassxreboot/keepassxc/blob/2.7.4/src/browser/BrowserShared.cpp#L49


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
