### PR TITLE
style: Address new needless borrow warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,9 +139,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Linux Dependencies
-        if: contains(matrix.os, 'ubuntu')
-        run: sudo apt-get install -y libusb-1.0-0 libusb-1.0-0-dev libdbus-1-dev
       - name: Install macOS Dependencies
         if: contains(matrix.os, 'macos')
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -135,9 +135,6 @@ jobs:
             experimental: true
     steps:
       - uses: actions/checkout@v3
-      - name: Install Linux Dependencies
-        if: contains(matrix.os, 'ubuntu')
-        run: sudo apt-get install -y libusb-1.0-0 libusb-1.0-0-dev libdbus-1-dev
       - name: Install macOS Dependencies
         if: contains(matrix.os, 'macos')
         run: |

--- a/src/config.rs
+++ b/src/config.rs
@@ -329,7 +329,7 @@ impl Config {
         let encrypted = aead
             .encrypt(nonce, data)
             .map_err(|_| anyhow!("Failed to encrypt database key"))?;
-        Ok(base64::encode(&encrypted))
+        Ok(base64::encode(encrypted))
     }
 
     #[cfg(feature = "encryption")]

--- a/src/keepassxc/messages/structs.rs
+++ b/src/keepassxc/messages/structs.rs
@@ -699,7 +699,7 @@ mod tests {
         let (_, client_id) = nacl_nonce();
 
         let exchange_message_context = mock_kpxc_initialise(&host_seckey);
-        let change_public_key_request = ChangePublicKeysRequest::new(&client_id, &host_pubkey);
+        let change_public_key_request = ChangePublicKeysRequest::new(client_id, &host_pubkey);
         let change_public_key_response = change_public_key_request.send();
         assert!(change_public_key_response.is_ok());
         let change_public_key_response = change_public_key_response.unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -749,7 +749,7 @@ fn lock_database<T: AsRef<Path>>(config_path: T) -> Result<()> {
     let (client_id, _, _) = start_session()?;
 
     let ld_req = LockDatabaseRequest::new();
-    let (ld_resp, _) = ld_req.send(&client_id, false)?;
+    let (ld_resp, _) = ld_req.send(client_id, false)?;
 
     ld_resp.check(&ld_req.get_action())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,7 +70,7 @@ pub fn get_socket_path() -> Result<PathBuf> {
             let get_socket_path_with_name = |name: &str| -> Result<PathBuf> {
                 let socket_dir = if cfg!(windows) && name == KEEPASS_SOCKET_NAME_LEGACY {
                     let temp_dir = std::env::temp_dir();
-                    let temp_dir = std::fs::canonicalize(&temp_dir)?;
+                    let temp_dir = std::fs::canonicalize(temp_dir)?;
                     PathBuf::from(format!(
                         "\\\\.\\pipe\\\\{}\\{}",
                         &temp_dir.to_string_lossy()[4..],
@@ -414,7 +414,7 @@ pub fn to_encrypted_json<M: serde::Serialize>(request: &M, nonce: &NaClNonce) ->
     let encrypted = client_box
         .encrypt(nonce, json.as_bytes())
         .map_err(|_| CryptionError(true))?;
-    let encrypted = base64::encode(&encrypted);
+    let encrypted = base64::encode(encrypted);
     Ok(encrypted)
 }
 


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`c4cac7e`](https://github.com/Frederick888/git-credential-keepassxc/pull/56/commits/c4cac7e1d50b383c3098e48d1467a2ac19f73980) style: Address new needless borrow warnings

[1] https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow


### [`1177e13`](https://github.com/Frederick888/git-credential-keepassxc/pull/56/commits/1177e134b781a7e925e958ae9f5d56f3ee99ba80) ci: Stop explicitly installing Linux dependencies

CI was failing as it tried to install libdbus-dev 1.12.16-2ubuntu2.2,
which doesn't exist in Azure's mirror (guess they had a hiccup when
synchronising).

These Linux dependencies were migrated from Travis CI and actually don't
need to be explicitly installed in GitHub Actions.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
