### PR TITLE
style: Inline format!() arguments

### DIFF
--- a/src/keepassxc/messages/primitives.rs
+++ b/src/keepassxc/messages/primitives.rs
@@ -22,7 +22,7 @@ impl<'de> Deserialize<'de> for KeePassBoolean {
         match s.as_str() {
             "true" => Ok(KeePassBoolean(true)),
             "false" => Ok(KeePassBoolean(false)),
-            _ => Err(serde::de::Error::custom(format!("Unknown boolean {}", s))),
+            _ => Err(serde::de::Error::custom(format!("Unknown boolean {s}"))),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -917,7 +917,7 @@ fn main() {
             error!("{}, Caused by: {}", e, source);
         } else {
             // failed to initialise LOGGER
-            println!("{}, Caused by: {}", e, source);
+            println!("{e}, Caused by: {source}");
         }
         std::process::exit(1);
     }

--- a/src/utils/socket.rs
+++ b/src/utils/socket.rs
@@ -182,7 +182,7 @@ impl SocketPath for WindowsSocketPath260 {
 
     #[cfg(target_os = "windows")]
     fn get_path(&self) -> Result<PathBuf> {
-        let result = PathBuf::from(format!(r#"\\.\pipe\{}"#, KEEPASS_SOCKET_NAME));
+        let result = PathBuf::from(format!(r#"\\.\pipe\{KEEPASS_SOCKET_NAME}"#));
         connectable_or_error(result)
     }
 
@@ -201,7 +201,7 @@ impl SocketPath for WindowsSocketPath262 {
     #[cfg(target_os = "windows")]
     fn get_path(&self) -> Result<PathBuf> {
         let pipe_with_username = KEEPASS_SOCKET_NAME.to_owned() + "_" + &std::env::var("USERNAME")?;
-        let result = PathBuf::from(format!(r#"\\.\pipe\{}"#, pipe_with_username));
+        let result = PathBuf::from(format!(r#"\\.\pipe\{pipe_with_username}"#));
         connectable_or_error(result)
     }
 


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`d79950f`](https://github.com/Frederick888/git-credential-keepassxc/pull/63/commits/d79950f8a9abda8fb078db9adcf43b291911113e) style: Inline format!() arguments

[1] https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No.
