### PR TITLE
Group filter `--group` and `--git-groups`

### DIFF
--- a/src/keepassxc.rs
+++ b/src/keepassxc.rs
@@ -17,4 +17,28 @@ impl Group {
             ..Default::default()
         }
     }
+
+    pub fn get_flat_groups(&self) -> Vec<FlatGroup> {
+        let flat_self = FlatGroup::new(&self.name, &self.uuid);
+        let mut flat_groups = vec![flat_self];
+        for child in &self.children {
+            flat_groups.extend(child.get_flat_groups());
+        }
+        flat_groups
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Default, Debug)]
+pub struct FlatGroup {
+    pub name: String,
+    pub uuid: String,
+}
+
+impl FlatGroup {
+    pub fn new<T: Into<String>>(name: T, uuid: T) -> Self {
+        Self {
+            name: name.into(),
+            uuid: uuid.into(),
+        }
+    }
 }


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`7065583`](https://github.com/Frederick888/git-credential-keepassxc/pull/65/commits/706558352688d4a47c1793b80b6bce10e7cba217) refactor: Move GitCredentialMessage ops to impl



### [`d33e1ec`](https://github.com/Frederick888/git-credential-keepassxc/pull/65/commits/d33e1ec8e627d24a52dee85e939b40d0c43c4967) feat(get,totp,store): Group filter --group and --git-groups

Filter login entries by group names provided by --group option. This
option can be repeated.

Since the store operation consists of getting existing entries then
update or create an entry, this option also applies to store. One minor
difference from get is that when a new entry is created, --group options
at the global position are ignored, i.e. it uses the first local --group
option if it's present, or the dedicated group created by
git-credential-keepassxc configure.

Also a new --git-groups option is added to filter login entries using
the names of the dedicated groups. Note that it filters all entries by
all groups from all databases, which can lead to unexpected results if a
user has more than one databases with different dedicated group names.
This is a limitation from KeePassXC as we don't get database UUIDs here.

Requires KeePassXC >= 2.6.0 [1]. These two options are ignored if used
with any older KeePassXC.

[1] https://github.com/keepassxreboot/keepassxc/pull/4111


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

Closes #50