### PR TITLE
feat(store): Add `--create-in` option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ pub struct MainArgs {
     /// Takes one argument in the format of [<MAX_RETRIES>[,<INTERVAL_MS>]]. Use 0 to retry indefinitely. The default interval is 1000ms.
     #[clap(long, value_parser, verbatim_doc_comment)]
     pub unlock: Option<UnlockOptions>,
-    /// Group(s) to get credentials from or the group to store the credential to
+    /// Group(s) to get credentials from
     #[clap(long, value_parser)]
     pub group: Vec<String>,
     /// Get credentials from the dedicated group created by 'configure' subcommand
@@ -92,7 +92,7 @@ pub struct SubGetArgs {
     /// Try getting TOTP
     #[clap(long, value_parser, conflicts_with = "raw")]
     pub totp: bool,
-    /// Group(s) to get credentials from or the group to store the credential to
+    /// Group(s) to get credentials from
     #[clap(long, value_parser, conflicts_with = "raw")]
     pub group: Vec<String>,
     /// Get credentials from the dedicated group created by 'configure' subcommand
@@ -149,7 +149,7 @@ impl GetOperation for SubGetArgs {
 /// Get TOTP
 #[derive(Args)]
 pub struct SubTotpArgs {
-    /// Group(s) to get credentials from or the group to store the credential to
+    /// Group(s) to get credentials from
     #[clap(long, value_parser)]
     pub group: Vec<String>,
     /// Get credentials from the dedicated group created by 'configure' subcommand
@@ -199,7 +199,10 @@ impl HasLocalEntryFilters for SubTotpArgs {}
 /// Store credential (used by Git)
 #[derive(Args)]
 pub struct SubStoreArgs {
-    /// Group(s) to get credentials from or the group to store the credential to
+    /// Create new entries in specified group instead of the one created by 'configure' subcommand
+    #[clap(long, value_parser)]
+    pub create_in: Option<String>,
+    /// Group(s) to get credentials from
     #[clap(long, value_parser)]
     pub group: Vec<String>,
     /// Get credentials from the dedicated group created by 'configure' subcommand

--- a/src/main.rs
+++ b/src/main.rs
@@ -717,7 +717,7 @@ fn store_login<T: AsRef<Path>>(
             );
         }
         let database = databases.first().unwrap();
-        let (group, group_uuid) = if let Some(group) = args.group.first() {
+        let (group, group_uuid) = if let Some(ref group) = args.create_in {
             let gg_req = GetDatabaseGroupsRequest::new();
             let (gg_resp, _) = gg_req.send(&client_id, false)?;
             let group_uuid = gg_resp


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`3d3a35b`](https://github.com/Frederick888/git-credential-keepassxc/pull/66/commits/3d3a35b6169af94d850177bbb009694d597d0ac5) feat(store): Add --create-in option

In [1] the local --group option was used for this purpose. However this
can be somewhat confusing. So adding a separate option and make
--group's behaviour consistent across different subcommands.

[1] https://github.com/Frederick888/git-credential-keepassxc/commit/d33e1ec8e627d24a52dee85e939b40d0c43c4967


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No. `--group` has not been released yet.
