### PR TITLE
Implement `groups` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,7 @@ dependencies = [
  "slog-term",
  "strum 0.24.1",
  "sysinfo",
+ "tabwriter",
  "which",
  "yubico_manager",
 ]
@@ -1701,6 +1702,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabwriter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36205cfc997faadcc4b0b87aaef3fbedafe20d38d4959a7ca6ff803564051111"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "tauri-winrt-notification"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +1893,12 @@ name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,24 +20,24 @@ encryption = ["aes-gcm/aes", "aes-gcm/alloc"]
 yubikey = ["yubico_manager", "encryption"]
 
 [dependencies]
+aes-gcm = { version = "0.10.1", default-features = false }
+anyhow = "1.0.28"
+base64 = "0.13.0"
+clap = { version = "3.1.18", features = ["derive"] }
+crypto_box = "0.8.1"
+directories-next = "2.0.0"
+notify-rust = { version = "4.5.9", optional = true }
+num_enum = "0.5.2"
+once_cell = "1.3.1"
+rand = "0.8.3"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.52"
-crypto_box = "0.8.1"
-base64 = "0.13.0"
-rand = "0.8.3"
-clap = { version = "3.1.18", features = ["derive"] }
 slog = "2.5.2"
 slog-term = "2.5.0"
-anyhow = "1.0.28"
-once_cell = "1.3.1"
-sysinfo = "0.26.2"
-directories-next = "2.0.0"
-yubico_manager = { version = "0.9.0", optional = true }
-aes-gcm = { version = "0.10.1", default-features = false }
-notify-rust = { version = "4.5.9", optional = true }
-which = "4.0.2"
 strum = { version = "0.24.0", features = ["derive"] }
-num_enum = "0.5.2"
+sysinfo = "0.26.2"
+which = "4.0.2"
+yubico_manager = { version = "0.9.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 prctl = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ slog = "2.5.2"
 slog-term = "2.5.0"
 strum = { version = "0.24.0", features = ["derive"] }
 sysinfo = "0.26.2"
+tabwriter = "1.2.1"
 which = "4.0.2"
 yubico_manager = { version = "0.9.0", optional = true }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,7 @@ pub struct MainArgs {
     /// Specify KeePassXC socket path (environment variable: KEEPASSXC_BROWSER_SOCKET_PATH)
     #[clap(short, long, value_parser)]
     pub socket: Option<String>,
-    /// Try unlocking database. Applies to get, totp, and store only.
+    /// Try unlocking database. Applies to get, totp, store, and groups only.
     /// Takes one argument in the format of [<MAX_RETRIES>[,<INTERVAL_MS>]]. Use 0 to retry indefinitely. The default interval is 1000ms.
     #[clap(long, value_parser, verbatim_doc_comment)]
     pub unlock: Option<UnlockOptions>,
@@ -53,6 +53,7 @@ pub enum Subcommands {
     Store(SubStoreArgs),
     Erase(SubEraseArgs),
     Lock(SubLockArgs),
+    Groups(SubGroupsArgs),
     GeneratePassword(SubGeneratePasswordArgs),
     Configure(SubConfigureArgs),
     Caller(SubCallerArgs),
@@ -69,6 +70,7 @@ impl Subcommands {
             Self::Store(_) => "store",
             Self::Erase(_) => "erase",
             Self::Lock(_) => "lock",
+            Self::Groups(_) => "groups",
             Self::GeneratePassword(_) => "generate-password",
             Self::Configure(_) => "configure",
             Self::Caller(_) => "caller",
@@ -232,6 +234,14 @@ pub struct SubEraseArgs {}
 /// Lock KeePassXC database
 #[derive(Args)]
 pub struct SubLockArgs {}
+
+/// List KeePassXC database groups
+#[derive(Args)]
+pub struct SubGroupsArgs {
+    /// Show raw output from KeePassXC
+    #[clap(long, value_parser)]
+    pub raw: bool,
+}
 
 /// Generate a password
 #[derive(Args)]

--- a/src/keepassxc.rs
+++ b/src/keepassxc.rs
@@ -18,27 +18,30 @@ impl Group {
         }
     }
 
-    pub fn get_flat_groups(&self) -> Vec<FlatGroup> {
-        let flat_self = FlatGroup::new(&self.name, &self.uuid);
+    pub fn get_flat_groups<'a>(&'a self, mut parents: Vec<&'a str>) -> Vec<FlatGroup<'a>> {
+        let flat_self = FlatGroup::new(&self.name, &self.uuid, &parents);
+        parents.push(&self.name);
         let mut flat_groups = vec![flat_self];
         for child in &self.children {
-            flat_groups.extend(child.get_flat_groups());
+            flat_groups.extend(child.get_flat_groups(parents.clone()));
         }
         flat_groups
     }
 }
 
 #[derive(Clone, Serialize, Deserialize, Default, Debug)]
-pub struct FlatGroup {
-    pub name: String,
-    pub uuid: String,
+pub struct FlatGroup<'a> {
+    pub name: &'a str,
+    pub uuid: &'a str,
+    pub parents: Vec<&'a str>,
 }
 
-impl FlatGroup {
-    pub fn new<T: Into<String>>(name: T, uuid: T) -> Self {
+impl<'a> FlatGroup<'a> {
+    pub fn new(name: &'a str, uuid: &'a str, parents: &[&'a str]) -> Self {
         Self {
-            name: name.into(),
-            uuid: uuid.into(),
+            name,
+            uuid,
+            parents: Vec::from(parents),
         }
     }
 }

--- a/src/keepassxc/messages/structs.rs
+++ b/src/keepassxc/messages/structs.rs
@@ -611,7 +611,7 @@ impl GetDatabaseGroupsResponse {
     pub fn get_flat_groups(&self) -> Vec<FlatGroup> {
         self.get_groups()
             .iter()
-            .map(Group::get_flat_groups)
+            .map(|g| g.get_flat_groups(vec![]))
             .fold(vec![], |mut acc, mut x| {
                 acc.append(&mut x);
                 acc


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`3fe4898`](https://github.com/Frederick888/git-credential-keepassxc/pull/67/commits/3fe489823bdd811ef6de76a1d61ad886d4b99227) style: Sort dependencies alphabetically



### [`9f45982`](https://github.com/Frederick888/git-credential-keepassxc/pull/67/commits/9f45982ff2cc7a43cb8fd02a05617297721423ed) feat(groups): Add groups subcommand

By default it lists the groups using tabwriter [1]. Option --raw is
still available.

This is added mainly because I plan to allow UUIDs as --group values.

[1] https://crates.io/crates/tabwriter


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
