### PR TITLE
Add FreeBSD support.

### DIFF
--- a/src/utils/socket.rs
+++ b/src/utils/socket.rs
@@ -25,6 +25,7 @@ pub fn get_socket_path() -> Result<PathBuf> {
         Box::new(LinuxSocketPath272),
         Box::new(WindowsSocketPath262),
         Box::new(WindowsSocketPathNatMsg),
+        Box::new(FreeBSDSocketPath274),
     ];
     let winner = candidates
         .iter()
@@ -48,6 +49,23 @@ pub fn get_socket_path() -> Result<PathBuf> {
 trait SocketPath {
     fn get_path(&self) -> Result<PathBuf>;
     fn matches_os(&self) -> bool;
+}
+
+struct FreeBSDSocketPath274;
+impl SocketPath for FreeBSDSocketPath274 {
+    fn get_path(&self) -> Result<PathBuf> {
+        let base_dirs = directories_next::BaseDirs::new()
+            .ok_or_else(|| anyhow!("Failed to initialise base_dirs"))?;
+        let result = base_dirs
+            .runtime_dir()
+            .ok_or_else(|| anyhow!("Failed to locate runtime_dir automatically"))?
+            .join(KEEPASS_SOCKET_NAME);
+        exist_or_error(result)
+    }
+
+    fn matches_os(&self) -> bool {
+        cfg!(target_os = "freebsd")
+    }
 }
 
 struct LinuxSocketPathLegacy;


### PR DESCRIPTION
# Description

Using on FreeBSD fails, as there is no specific case that matches.
It works just like on Linux, on path `$XDG_RUNTIME_DIR/org.keepassxc.KeePassXC.BrowserServer`.

# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
<!-- Do NOT write here! -->
<!-- It will be filled in by GitHub Actions automatically. -->
<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [ ] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

No, it only adds a new case for FreeBSD.
