### PR TITLE
ci: Define gh-ph permissions

### DIFF
--- a/.github/workflows/gh-ph.yml
+++ b/.github/workflows/gh-ph.yml
@@ -3,6 +3,10 @@ name: Pull request history
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   gh-ph:
     name: Add commit history to pull request description

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,28 +1,17 @@
 name: GitLab Sync
 
-on: push
+on: [push, create, delete]
 
 jobs:
-  branch-sync:
-    name: Synchronise Branches
+  sync:
+    name: Synchronise to GitLab
     runs-on: ubuntu-latest
     steps:
-    - name: repo-sync
-      uses: wei/git-sync@v3
-      with:
-        source_repo: "https://github.com/Frederick888/git-credential-keepassxc.git"
-        source_branch: "refs/remotes/source/*"
-        destination_repo: "https://Frederick888:${{ secrets.GITLAB_ACCESS_TOKEN }}@git.tsundere.moe/Frederick888/git-credential-keepassxc.git"
-        destination_branch: "refs/heads/*"
-
-  tag-sync:
-    name: Synchronise Tags
-    runs-on: ubuntu-latest
-    steps:
-    - name: repo-sync
-      uses: wei/git-sync@v3
-      with:
-        source_repo: "https://github.com/Frederick888/git-credential-keepassxc.git"
-        source_branch: "refs/tags/*"
-        destination_repo: "https://Frederick888:${{ secrets.GITLAB_ACCESS_TOKEN }}@git.tsundere.moe/Frederick888/git-credential-keepassxc.git"
-        destination_branch: "refs/tags/*"
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: action-pack/gitlab-sync@v3
+        with:
+          username: Frederick888
+          url: "https://git.tsundere.moe/Frederick888/git-credential-keepassxc.git"
+          token: ${{ secrets.GITLAB_ACCESS_TOKEN }}


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`6d5080b`](https://github.com/Frederick888/git-credential-keepassxc/pull/82/commits/6d5080b639c70b50cec52e6a537f9eca8d72e9f8) ci: Define gh-ph permissions

So that when it runs on a PR from a fork, whose owner doesn't have write
access to this repository, can still use this Action.


### [`cf0301e`](https://github.com/Frederick888/git-credential-keepassxc/pull/82/commits/cf0301e300b28e755494bcacc28c9d0fb79cc8e7) ci: Migrate to action-pack/gitlab-sync

GitHub user 'wei' does not exist any more.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
