### PR TITLE
fix: Wrong strict-caller log when skipping caller verification

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -362,6 +362,9 @@ fn verify_caller(config: &Config) -> Result<Option<CurrentCaller>> {
     if config.count_callers() == 0
         && (cfg!(not(feature = "strict-caller")) || config.count_databases() == 0)
     {
+        #[cfg(not(feature = "strict-caller"))]
+        info!("Caller verification skipped as no caller profiles defined");
+        #[cfg(feature = "strict-caller")]
         info!(
             "Caller verification skipped as no caller profiles defined and strict-caller disabled"
         );

--- a/src/utils/socket.rs
+++ b/src/utils/socket.rs
@@ -163,8 +163,7 @@ impl SocketPath for WindowsSocketPathNatMsg {
     #[cfg(target_os = "windows")]
     fn get_path(&self) -> Result<PathBuf> {
         let username = std::env::var("USERNAME")?;
-        let result =
-            PathBuf::from(r#"\\.\pipe\keepassxc\"#.to_owned() + &username + r#"\kpxc_server"#);
+        let result = PathBuf::from(r"\\.\pipe\keepassxc\".to_owned() + &username + r"\kpxc_server");
         connectable_or_error(result)
     }
 


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`2b32205`](https://github.com/Frederick888/git-credential-keepassxc/pull/86/commits/2b322050bd29b5ce4a39462c1285fda14953240a) fix: Wrong strict-caller log when skipping caller verification



### [`27dfb99`](https://github.com/Frederick888/git-credential-keepassxc/pull/86/commits/27dfb9931d02552e5404e7436138a33fdcd6e900) chore: Remove unnecessary hashes around raw string literals

[1] https://rust-lang.github.io/rust-clippy/master/index.html#needless_raw_string_hashes


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
