### PR TITLE
feat: Show build type (debug/release) in --version

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,10 +62,17 @@ fn long_version() -> &'static str {
         features.push("yubikey".to_owned());
     }
     if features.is_empty() {
-        version
+        #[cfg(debug_assertions)]
+        let version = format!("{version} [debug]");
+        #[cfg(not(debug_assertions))]
+        let version = format!("{version} [release]");
+        Box::leak(Box::new(version)).as_str()
     } else {
         let features = features.join(", ");
-        let version = format!("{version} ({features})");
+        #[cfg(debug_assertions)]
+        let version = format!("{version} [debug] ({features})");
+        #[cfg(not(debug_assertions))]
+        let version = format!("{version} [release] ({features})");
         Box::leak(Box::new(version)).as_str()
     }
 }


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`acd322f`](https://github.com/Frederick888/git-credential-keepassxc/pull/89/commits/acd322f5b491478ffeae320349ef78dac8e21662) feat: Show build type (debug/release) in --version



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
