### PR TITLE
Fix GitLab sync

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,17 +1,28 @@
 name: GitLab Sync
 
-on: [push, create, delete]
+on: push
 
 jobs:
-  sync:
-    name: Synchronise to GitLab
+  branch-sync:
+    name: Synchronise Branches
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: action-pack/gitlab-sync@v3
-        with:
-          username: Frederick888
-          url: "https://git.tsundere.moe/Frederick888/git-credential-keepassxc.git"
-          token: ${{ secrets.GITLAB_ACCESS_TOKEN }}
+    - name: repo-sync
+      uses: wei/git-sync@v3
+      with:
+        source_repo: "https://github.com/Frederick888/git-credential-keepassxc.git"
+        source_branch: "refs/remotes/source/*"
+        destination_repo: "https://Frederick888:${{ secrets.GITLAB_ACCESS_TOKEN }}@git.tsundere.moe/Frederick888/git-credential-keepassxc.git"
+        destination_branch: "refs/heads/*"
+
+  tag-sync:
+    name: Synchronise Tags
+    runs-on: ubuntu-latest
+    steps:
+    - name: repo-sync
+      uses: wei/git-sync@v3
+      with:
+        source_repo: "https://github.com/Frederick888/git-credential-keepassxc.git"
+        source_branch: "refs/tags/*"
+        destination_repo: "https://Frederick888:${{ secrets.GITLAB_ACCESS_TOKEN }}@git.tsundere.moe/Frederick888/git-credential-keepassxc.git"
+        destination_branch: "refs/tags/*"

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: repo-sync
-      uses: wei/git-sync@v3
+      uses: Frederick888/git-sync@master
       with:
         source_repo: "https://github.com/Frederick888/git-credential-keepassxc.git"
         source_branch: "refs/remotes/source/*"
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: repo-sync
-      uses: wei/git-sync@v3
+      uses: Frederick888/git-sync@master
       with:
         source_repo: "https://github.com/Frederick888/git-credential-keepassxc.git"
         source_branch: "refs/tags/*"


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`d71a69d`](https://github.com/Frederick888/git-credential-keepassxc/pull/91/commits/d71a69dc76f3201bcdc313b01320a262f548e301) ci: Revert "Migrate to action-pack/gitlab-sync"

This reverts commit cf0301e300b28e755494bcacc28c9d0fb79cc8e7.


### [`7550b3c`](https://github.com/Frederick888/git-credential-keepassxc/pull/91/commits/7550b3cfdfae449dd1e1076335d7f5d9d99ad7e9) ci: Switch to fork of git-sync

[1] https://github.com/wei/git-sync/pull/37


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
