### PR TITLE
Support `ubuntu-20.04`, and also prepend the release artifact filenames with `git-credential-keepassxc_`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - ubuntu-20.04
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         features: [default, all]
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +101,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - ubuntu-20.04
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         features:
           - [default]
           - [all]
@@ -133,7 +141,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - ubuntu-20.04
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         features: [default, all]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,7 @@ jobs:
         shell: bash
         run: |
           zip -j "./${{ matrix.os }}-${{ steps.artifact_suffix.outputs.suffix }}.zip" target/release/git-credential-keepassxc target/release/git-credential-keepassxc.exe
-          echo "filename=${{ matrix.os }}-${{ steps.artifact_suffix.outputs.suffix }}" >> $GITHUB_OUTPUT
+          echo "filename=git-credential-keepassxc_${{ matrix.os }}-${{ steps.artifact_suffix.outputs.suffix }}" >> $GITHUB_OUTPUT
       - name: "Hash (Unix)"
         if: "!contains(matrix.os, 'windows')"
         run: |


### PR DESCRIPTION
# Description

# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`19eb704`](https://github.com/Frederick888/git-credential-keepassxc/pull/95/commits/19eb704bde3dbbd5af8ef7dedb44b74c8205cb08) feat(ci): Release: Support `ubuntu-20.04`

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>


### [`6ef71f8`](https://github.com/Frederick888/git-credential-keepassxc/pull/95/commits/6ef71f8a66a3fbd9e4dbd71fc8401edc2bb5c708) feat(ci): Release: Prepend the release artifact filenames with `git-credential-keepassxc_`

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->

No
