### PR TITLE
Fix clippy issues

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -27,6 +27,7 @@ check:
 
 clippy:
     for feature in default notification encryption yubikey all; do \
+        cargo clippy --features=$feature --locked -- -D warnings; \
         cargo clippy --features=$feature --locked --tests -- -D warnings; \
     done
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -766,13 +766,15 @@ impl MockYubiKeyTrait {
     }
 }
 
+#[allow(dead_code)]
 #[cfg(feature = "yubikey")]
 struct YubiKey {
     yubi: Yubico,
     device: yubico_manager::Device,
 }
 
-#[cfg(all(not(test), feature = "yubikey"))]
+#[allow(dead_code)]
+#[cfg(feature = "yubikey")]
 impl YubiKey {
     fn new() -> Result<Self> {
         let mut yubi = Yubico::new();
@@ -781,6 +783,7 @@ impl YubiKey {
     }
 }
 
+#[allow(dead_code)]
 #[cfg(feature = "yubikey")]
 impl YubiKeyTrait for YubiKey {
     fn read_serial_number(&mut self) -> Result<u32, YubicoError> {

--- a/src/utils/callers.rs
+++ b/src/utils/callers.rs
@@ -10,6 +10,7 @@ use sysinfo::{get_current_pid, ProcessRefreshKind, RefreshKind, System, UpdateKi
 #[derive(Debug)]
 pub struct CurrentCaller {
     pub path: PathBuf,
+    #[allow(dead_code)]
     pub pid: u32,
     #[cfg(unix)]
     pub uid: u32,


### PR DESCRIPTION
# Description

# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`4a54988`](https://github.com/Frederick888/git-credential-keepassxc/pull/98/commits/4a54988b988e1ae47b731793c5d83d0761f606d7) style: Suppress dead code warnings in test builds

They only happen in tests. It's too much of an overkill to add not(test)
to fix them.


### [`3ee4b6f`](https://github.com/Frederick888/git-credential-keepassxc/pull/98/commits/3ee4b6f1ed07048011917e555a4b0d426369416d) style: Allow dead code on CurrentCaller.pid

It's only actually read when 'notification' feature is enabled, but I'll
need a bunch of conditional compilation stuff in tests too if I do a
cfg() here, which is not worth it.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
