### PR TITLE
style: Replace map_or() with is_some_and()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn associated_databases<T: AsRef<str>>(
                     }
                 };
                 if let Ok((ref taso_resp, _)) = taso_resp {
-                    success = taso_resp.success.as_ref().map_or(false, |s| *s.as_ref());
+                    success = taso_resp.success.as_ref().is_some_and(|s| *s.as_ref());
                 }
                 if taso_resp.is_err() || !success {
                     warn!(


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`d2d3e9f`](https://github.com/Frederick888/git-credential-keepassxc/pull/104/commits/d2d3e9fcaabdca51b43ddc376792ddc90f5526d2) style: Replace map_or() with is_some_and()

[1] https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
