### PR TITLE
ci: Replace eregon/publish-release with ncipollo/release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,8 +249,11 @@ jobs:
     if: ${{ needs.create_release.outputs.is_pre == 'false' }}
     steps:
       - name: Publish Release
-        uses: eregon/publish-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          release_id: ${{ needs.create_release.outputs.release_id }}
+          allowUpdates: true
+          updateOnlyUnreleased: true
+          draft: false
+          omitPrereleaseDuringUpdate: true
+          omitBodyDuringUpdate: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`3eb34f0`](https://github.com/Frederick888/git-credential-keepassxc/pull/119/commits/3eb34f011d06a536722974f9d28ccfc5d7a132d5) ci: Replace eregon/publish-release with ncipollo/release-action

eregon/publish-release is archived.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Use subcommand names as scopes, e.g. feat(get): Fetch credentials with quantum physics.
Omitted if the PR changes some shared functionalities.
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
